### PR TITLE
✨ Making sure that when making an override on the proxyshape and a la…

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -724,6 +724,8 @@ ProxyShape::ProxyShape()
   m_hierarchyIterationLogics[0] = &m_findExcludedPrims;
   m_hierarchyIterationLogics[1] = &m_findUnselectablePrims;
   m_hierarchyIterationLogics[2] = &m_findLockedPrims;
+
+  triggerEvent("PostConstructProxyShape");
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -2425,6 +2427,7 @@ void ProxyShape::registerEvents()
   registerEvent("EditTargetChanged", AL::event::kUSDMayaEventType);
   registerEvent("SelectionStarted", AL::event::kUSDMayaEventType);
   registerEvent("SelectionEnded", AL::event::kUSDMayaEventType);
+  registerEvent("PostConstructProxyShape", AL::event::kUSDMayaEventType);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -724,8 +724,6 @@ ProxyShape::ProxyShape()
   m_hierarchyIterationLogics[0] = &m_findExcludedPrims;
   m_hierarchyIterationLogics[1] = &m_findUnselectablePrims;
   m_hierarchyIterationLogics[2] = &m_findLockedPrims;
-
-  triggerEvent("PostConstructProxyShape");
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -2427,7 +2425,6 @@ void ProxyShape::registerEvents()
   registerEvent("EditTargetChanged", AL::event::kUSDMayaEventType);
   registerEvent("SelectionStarted", AL::event::kUSDMayaEventType);
   registerEvent("SelectionEnded", AL::event::kUSDMayaEventType);
-  registerEvent("PostConstructProxyShape", AL::event::kUSDMayaEventType);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/pxr/maya/lib/usdMaya/transformWriter.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/transformWriter.cpp
@@ -428,7 +428,8 @@ UsdMayaTransformWriter::_PushTransformStack(
             }
             if(!foundOp) {
                 animChan.op = usdXformable.AddXformOp(
-                animChan.usdOpType, animChan.precision,
+                animChan.usdOpType,
+                animChan.precision,
                 animChan.opName,
                 animChan.isInverse);
             }

--- a/plugin/pxr/maya/lib/usdMaya/writeUtil.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/writeUtil.cpp
@@ -1006,7 +1006,11 @@ UsdMayaWriteUtil::WriteMetadataToPrim(
     }
 
     for (const auto& keyValue : adaptor.GetAllAuthoredMetadata()) {
-        prim.SetMetadata(keyValue.first, keyValue.second);
+        TfToken val;
+        prim.GetMetadata(keyValue.first, &val);
+        if(val != keyValue.second) {
+            prim.SetMetadata(keyValue.first, keyValue.second);
+        }
     }
     return true;
 }


### PR DESCRIPTION
Fixes to make overrides work for pxrUsdReferenceAssembly nodes and exporting with a overrideLayer with usdExport.

* XformOps are overrided propery -- no errors if xforms are found
* Reference  only burnt in if changed
* Metadata  only burnt in if changed
* Variants are only burnt in if changed
* metersperUnit only burnt in if changed
* upaxis only burnt in if changed

