### PR TITLE
 🐛 the reference was not properly added when there was no override

### DIFF
--- a/plugin/pxr/maya/lib/usdMaya/modelKindProcessor.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/modelKindProcessor.cpp
@@ -229,7 +229,7 @@ UsdMaya_ModelKindProcessor::_FixUpPrimKinds(
         // The kind of the root prim under which each reference was authored
         // informs how we will fix-up/fill-in kind on it and its ancestors.
         UsdPrim prim = stage->GetPrimAtPath(path);
-        if (!prim || !prim.IsDefined()) {
+        if (!prim) {
             continue;
         }
 

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -129,16 +129,10 @@ _AddReference(
     std::string refAssetPath,
     SdfPath refPrimPath = SdfPath())
 {
-    bool addReference = true;
-    if (prim.HasAuthoredReferences()){
-        std::string assetIdentifier;
-        SdfPath assetPrimPath;
-        _GetReferenceInfo(prim, &assetIdentifier, &assetPrimPath);
-        if (assetIdentifier.empty() || (refAssetPath == assetIdentifier)){
-            addReference = false;
-        }
-    }
-    if( addReference ) {
+    std::string assetIdentifier;
+    SdfPath assetPrimPath;
+    _GetReferenceInfo(prim, &assetIdentifier, &assetPrimPath);
+    if (assetIdentifier.empty() || refAssetPath.compare(assetIdentifier) != 0){
         if(!refPrimPath.IsEmpty()) {
             refs.AddReference(SdfReference(refAssetPath, refPrimPath));
         }
@@ -147,7 +141,6 @@ _AddReference(
         }
     }
 }
-
 
 /* static */
 bool

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -129,17 +129,21 @@ _AddReference(
     std::string refAssetPath,
     SdfPath refPrimPath = SdfPath())
 {
+    bool addReference = true;
     if (prim.HasAuthoredReferences()){
         std::string assetIdentifier;
         SdfPath assetPrimPath;
         _GetReferenceInfo(prim, &assetIdentifier, &assetPrimPath);
-        if (!assetIdentifier.empty() && (refAssetPath != assetIdentifier)){
-             if(!refPrimPath.IsEmpty()) {
-                refs.AddReference(SdfReference(refAssetPath, refPrimPath));
-             }
-             else {
-                refs.AddReference(SdfReference(refAssetPath));
-             }
+        if (assetIdentifier.empty() || (refAssetPath == assetIdentifier)){
+            addReference = false;
+        }
+    }
+    if( addReference ) {
+        if(!refPrimPath.IsEmpty()) {
+            refs.AddReference(SdfReference(refAssetPath, refPrimPath));
+        }
+        else {
+            refs.AddReference(SdfReference(refAssetPath));
         }
     }
 }


### PR DESCRIPTION
bug introduced where we were not getting references on empty exports with overrides.