### PR TITLE
🐛 Making sure usdExport works with scalePivot and rotatePivot

### DIFF
--- a/lib/fileio/transformWriter.cpp
+++ b/lib/fileio/transformWriter.cpp
@@ -420,7 +420,9 @@ UsdMayaTransformWriter::_PushTransformStack(
                     usdXformable.GetOrderedXformOps(&resetsXformStack);
             for (auto op_iter = ops.begin(); op_iter != ops.end(); ++op_iter) {
                 const UsdGeomXformOp& thisOp = *op_iter;
-                if (thisOp.GetOpType() == animChan.usdOpType) {
+                if (thisOp.GetName() == animChan.opName 
+                    && thisOp.GetOpType() == animChan.usdOpType
+                    && thisOp.IsInverseOp() == animChan.isInverse) {
                         animChan.op = thisOp;
                         foundOp = true;
                         break;


### PR DESCRIPTION
rotatePivot and scalePivot did not properly get applied during export. In this case it just wrote out the rotatePivot and gave an xformOp with (0,3,1) (incorrectly too) which made it not be in the place it should be.

![image](https://user-images.githubusercontent.com/454591/80237627-57b85480-865d-11ea-85cc-83214250c71c.png)

With this fix it does check the XformType, name and inverse to make sure we haven't added it yet.
This fixes the problem and it is now exported correctly with inversed ops for the scale and rotatePivot.

So the cube in this case is in origo and has scale and rotatePivot applied. Looks good in maya like this:
![image](https://user-images.githubusercontent.com/454591/80237932-d3b29c80-865d-11ea-8547-174b5f81f79b.png)
but after export it looks like this in usdview:
![image](https://user-images.githubusercontent.com/454591/80238053-06f52b80-865e-11ea-85d4-0eccfc60ca5c.png)
And you can see the xformOp is just one rotatePivot and also gets incorrect values on the rotate, that is the scale values.
With this fix it looks like this:
![image](https://user-images.githubusercontent.com/454591/80238180-402d9b80-865e-11ea-9068-73e021bb8452.png)
Now the xformops matches what is in Maya and is correctly transformed.